### PR TITLE
separating the executive from the library for reuse by other packages

### DIFF
--- a/lib/RevdepScanner.hs
+++ b/lib/RevdepScanner.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE LambdaCase #-}
+
+module RevdepScanner
+  ( prettyProblems
+  , prettyMatches
+  , prettyResults
+  , ConstraintMap
+  , MatchMode(Matching, NonMatching)
+  , Debug
+  , Mode(HelpMode, NormalMode)
+  , lookupResults
+  , args
+  , runOpaque
+  , runTransparent
+  , parseAll
+  ) where
+
+import           Conduit                    (ConduitT, decodeUtf8LenientC,
+                                             iterMC, sinkLazy, (.|))
+import           Control.Monad.Trans.Accum  (AccumT, add, evalAccumT, look)
+import qualified Data.ByteString            as BS
+import           Data.Conduit.Process       (sourceProcessWithStreams)
+import           Data.Function              (on)
+import           Data.HashMap.Strict        (HashMap)
+import qualified Data.HashMap.Strict        as M
+import           Data.HashSet               (HashSet)
+import qualified Data.HashSet               as S
+import           Data.List                  as L
+import           Data.List.NonEmpty         (NonEmpty (..))
+import qualified Data.List.NonEmpty         as NE
+import           Data.Monoid                (Any, Last, Sum (Sum))
+import           Data.Parsable              (ParseError, choice, eof, lift,
+                                             parse, parser, toString, try)
+import qualified Data.Text.Lazy             as TL
+import           Data.Void
+import           Distribution.Portage.Types
+import           System.Exit                (ExitCode)
+import           System.IO                  (Handle, stderr, stdout)
+import           System.Process             (delegate_ctlc, proc)
+import           Text.Parsec.Char           (anyChar)
+import           Text.Parsec.String         (Parser)
+
+lookupResults ::
+     MatchMode -> Package -> ConstraintMap -> HashMap Revdep (HashSet ParsedDep)
+lookupResults mode p0@(Package c0 n0 _ _ _) m0 =
+  case M.lookup (c0, n0) m0 of
+    Just m  -> foldr (M.unionWith S.union . go) M.empty (M.toList m)
+    Nothing -> M.empty
+  where
+    go :: (Revdep, HashSet ParsedDep) -> HashMap Revdep (HashSet ParsedDep)
+    go (r, s)
+      | any check s = M.singleton r s
+      | otherwise = M.empty
+    check d =
+      case (mode, d) of
+        (Matching, Left cd)      -> doesConstraintMatch cd p0
+        (Matching, Right (c, n)) -> c == c0 && n == n0
+        (NonMatching, Left cd)   -> not (doesConstraintMatch cd p0)
+        (NonMatching, Right _)   -> False
+
+-- Command line
+type Debug = Any
+
+data MatchMode
+  = Matching
+  | NonMatching
+  deriving (Show, Eq, Ord)
+
+data Mode
+  = HelpMode
+  | NormalMode (Last MatchMode) (Last Repository) Debug
+  deriving (Show, Eq, Ord)
+
+instance Semigroup Mode where
+  HelpMode <> _ = HelpMode
+  _ <> HelpMode = HelpMode
+  NormalMode m1 r1 d1 <> NormalMode m2 r2 d2 =
+    NormalMode (m1 <> m2) (r1 <> r2) (d1 <> d2)
+
+instance Monoid Mode where
+  mempty = NormalMode mempty mempty mempty
+
+-- Types
+type ConstraintPkg = (Category, PkgName)
+
+type Revdep = (Category, PkgName, Version, Slot, Repository)
+
+type BasicDep = (Category, PkgName)
+
+type ParsedDep = Either ConstrainedDep BasicDep
+
+-- | Organized by @(Category, PkgName)@
+--
+--   The inner map is keyed by the reverse dependency and contains a set of
+--   constraints that match the same @(Category, PkgName)@ as the outermost key.
+type ConstraintMap = HashMap ConstraintPkg (HashMap Revdep (HashSet ParsedDep))
+
+insertCM :: Revdep -> ParsedDep -> ConstraintMap -> ConstraintMap
+insertCM revdep dep cmap0 =
+  unionCM cmap0
+    $ M.singleton (ccat, cpkg) (M.singleton revdep (S.singleton dep))
+  where
+    (ccat, cpkg) =
+      case dep of
+        Left (ConstrainedDep _ c p _ _ _) -> (c, p)
+        Right bDep                        -> bDep
+
+unionCM :: ConstraintMap -> ConstraintMap -> ConstraintMap
+unionCM = M.unionWith (M.unionWith S.union)
+
+prettyProblems ::
+     Package -> HashMap Revdep (HashSet ParsedDep) -> NonEmpty String
+prettyProblems p m
+  | M.null m = NE.singleton $ toString p ++ ": No problematic packages found!"
+  | otherwise = (toString p ++ ":") :| prettyResults m
+
+prettyMatches ::
+     Package -> HashMap Revdep (HashSet ParsedDep) -> NonEmpty String
+prettyMatches p m
+  | M.null m = NE.singleton $ toString p ++ ": No matches found!"
+  | otherwise = (toString p ++ ":") :| prettyResults m
+
+prettyResults :: HashMap Revdep (HashSet ParsedDep) -> [String]
+prettyResults m =
+  sortBy (compare `on` fst) (M.toList m) >>= \((c, n, v, sl, r), s) ->
+    let p = Package c n (Just v) (Just sl) (Just r)
+        svs = sortBy cmp (S.toList s)
+     in ["    " ++ toString p, "        ( " ++ unwords (map toStr svs) ++ " )"]
+  where
+    cmp :: ParsedDep -> ParsedDep -> Ordering
+    cmp pd1 pd2 =
+      case (pd1, pd2) of
+        (Left (ConstrainedDep _ _ _ v1 _ _), Left (ConstrainedDep _ _ _ v2 _ _)) ->
+          v1 `compare` v2
+        (Left _, Right _) -> GT
+        (Right _, Left _) -> LT
+        (_, _) -> EQ
+    toStr :: ParsedDep -> String
+    toStr =
+      \case
+        Left cd -> toString cd
+        Right (c, n) -> toString $ Package c n Nothing Nothing Nothing
+
+-- Parsing
+parseAll :: TL.Text -> Either ParseError ConstraintMap
+parseAll t = do
+  cms <- evalAccumT (traverse parseLine (TL.lines t)) (Sum 1)
+  pure $ foldr unionCM M.empty cms
+  where
+    parseLine :: TL.Text -> AccumT (Sum Int) (Either ParseError) ConstraintMap
+    parseLine l = do
+      Sum i <- look
+      add (Sum 1)
+      lift $ parse lineParser ("line " ++ show i) (TL.unpack l)
+
+lineParser :: Parser ConstraintMap
+lineParser = do
+  ConstrainedDep Equal rdCat rdPkg rdVer (Just rdSlot) (Just rdRepo) <-
+    parser @ConstrainedDep -- parser from Data.Parsable
+  let revdep = (rdCat, rdPkg, rdVer, rdSlot, rdRepo)
+  foldr (insertCM revdep) M.empty <$> bruteForce
+  where
+    -- Start with char 0, see if it's a valid ConstrainedDep /or/ Package.
+    -- Try next char, see if it's a valid ConstrainedDep /or Package.
+    -- etc...
+    bruteForce :: Parser [ParsedDep]
+    bruteForce =
+      choice
+        [ try $ (:) <$> (Left <$> parser @ConstrainedDep) <*> bruteForce
+        , try $ do
+            Package c n Nothing _ _ <- parser
+            (Right (c, n) :) <$> bruteForce
+        , try $ [] <$ eof
+        , anyChar *> bruteForce
+        ]
+
+-- Util stuff
+-- | Run a command and capture stdout and stderr
+runOpaque ::
+     FilePath -- ^ executable path
+  -> [String] -- ^ arguments
+       -- | Exit code, stdout, stderr
+  -> IO (ExitCode, TL.Text, TL.Text)
+runOpaque exe a =
+  sourceProcessWithStreams
+    (proc exe a)
+    (pure ())
+    (decodeUtf8LenientC .| sinkLazy)
+    (decodeUtf8LenientC .| sinkLazy)
+
+-- | Run a command and dump stdout to @stdout@, stderr to @stderr@, also
+--   capturing both streams.
+runTransparent ::
+     FilePath -- ^ executable path
+  -> [String] -- ^ arguments
+       -- | Exit code, stdout, stderr
+  -> IO (ExitCode, TL.Text, TL.Text)
+runTransparent exe a =
+  sourceProcessWithStreams
+    (proc exe a) {delegate_ctlc = True}
+    (pure ())
+    (transSink stdout)
+    (transSink stderr)
+  where
+    transSink :: Handle -> ConduitT BS.ByteString Void IO TL.Text
+    transSink h = iterMC (BS.hPut h) .| decodeUtf8LenientC .| sinkLazy
+
+args :: Repository -> [String]
+args (Repository n) =
+  [ "--all"
+  , "--raw"
+  , "--unfiltered"
+  , "--repo"
+  , n
+  , "--atom"
+  , "--cpv"
+  , "--slot"
+  , "--attr"
+  , "depend"
+  , "--attr"
+  , "rdepend"
+  , "--attr"
+  , "bdepend"
+  , "-R"
+  , "--slot"
+  ]

--- a/revdep-scanner.cabal
+++ b/revdep-scanner.cabal
@@ -1,60 +1,91 @@
-cabal-version:      3.4
-name:               revdep-scanner
-version:            0.1.0.0
-synopsis:           Scan Gentoo repositories for reverse dependencies
+cabal-version:   3.4
+name:            revdep-scanner
+version:         0.1.0.0
+synopsis:        Scan Gentoo repositories for reverse dependencies
+tested-with:
+  GHC ==9.2.8
+   || ==9.4.8
+   || ==9.6.6
+   || ==9.8.4
+   || ==9.10.1
+   || ==9.12.1
 
-tested-with:        GHC == { 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
 -- description:
-homepage:           https://github.com/gentoo-haskell/revdep-scanner
-license:            AGPL-3.0-only
-license-file:       LICENSE
-author:             Gentoo Authors
-maintainer:         hololeap@protonmail.com
-copyright:          Copyright (C) 2025 Gentoo Authors
-category:           Development
-build-type:         Simple
+homepage:        https://github.com/gentoo-haskell/revdep-scanner
+license:         AGPL-3.0-only
+license-file:    LICENSE
+author:          Gentoo Authors
+maintainer:      hololeap@protonmail.com
+copyright:       Copyright (C) 2025 Gentoo Authors
+category:        Development
+build-type:      Simple
 extra-doc-files:
-    CHANGELOG.md
-    README.md
+  CHANGELOG.md
+  README.md
+
 -- extra-source-files:
 
 source-repository head
-    type:           git
-    location:       https://github.com/gentoo-haskell/revdep-scanner.git
-    branch:         main
+  type:     git
+  location: https://github.com/gentoo-haskell/revdep-scanner.git
+  branch:   main
 
 flag pedantic
-    description: Enable -Werror
-    default:     False
-    manual:      True
+  description: Enable -Werror
+  default:     False
+  manual:      True
+
+flag executable
+  description: Build executable
+  default:     True
+  manual:      True
 
 common warnings
-    ghc-options: -Wall
-    if flag(pedantic)
-        ghc-options:    -Werror
+  ghc-options: -Wall
+
+  if flag(pedantic)
+    ghc-options: -Werror
+
+common shared-properties
+  build-depends:
+    , base                  >=4.16     && <4.22
+    , bytestring            >=0.11.4.0 && <0.13
+    , conduit               ^>=1.3.0
+    , conduit-extra         >=1.1.12   && <1.4
+    , parsable              ^>=0.1
+    , portage-hs            ^>=0.1
+    , pretty-simple         ^>=4.1.1.0
+    , process               ^>=1.6.16
+    , text                  >=1.2.5.0  && <2.2
+    , transformers          >=0.5.6.2  && <0.7
+    , unordered-containers  ^>=0.2
+
+  default-language: GHC2021
 
 common exe
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+
+library
+  import:           warnings, shared-properties
+  build-depends:    parsec ^>=3.1
+  exposed-modules:  RevdepScanner
+  hs-source-dirs:   lib
+  default-language: GHC2021
 
 executable revdep-scanner
-    import:           warnings, exe
-    main-is:          Main.hs
-    -- other-modules:
-    -- other-extensions:
-    build-depends:
-        , base >=4.16 && <4.22
-        , parsable ^>=0.1
-        , portage-hs ^>=0.1
-        , bytestring >=0.11.4.0 && <0.13
-        , conduit-extra >=1.1.12 && <1.4
-        , conduit ^>=1.3.0
-        , directory ^>=1.3.6.2
-        , mtl >=2.2.2 && <2.4
-        , parsec ^>=3.1
-        , pretty-simple ^>=4.1.1.0
-        , process ^>=1.6.16
-        , unordered-containers ^>=0.2
-        , text >=1.2.5.0 && <2.2
-        , transformers >=0.5.6.2 && <0.7
-    hs-source-dirs:   src-exe
-    default-language: GHC2021
+  import:           warnings, shared-properties, exe
+
+  if !flag(executable)
+    buildable: False
+
+  main-is:          Main.hs
+
+  -- other-modules:
+  -- other-extensions:
+  build-depends:
+    , directory       ^>=1.3.6.2
+    , mtl             >=2.2.2    && <2.4
+    , revdep-scanner
+
+  hs-source-dirs:   src-exe
+  default-language: GHC2021

--- a/src-exe/Main.hs
+++ b/src-exe/Main.hs
@@ -1,202 +1,54 @@
-{-# Language DeriveTraversable #-}
-{-# Language DerivingVia #-}
-{-# Language LambdaCase #-}
-{-# Language TypeApplications #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE LambdaCase  #-}
 
 module Main where
 
-import Conduit
-import Control.Monad
-import Control.Monad.Trans.Accum
-import qualified Data.ByteString as BS
-import Data.Function (on)
-import Data.List as L
-import qualified Data.List.NonEmpty as NE
-import           Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.HashMap.Strict as M
-import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashSet as S
-import           Data.HashSet (HashSet)
-import Data.Maybe (fromMaybe, isJust, isNothing)
-import qualified Data.Text.Lazy as TL
-import Data.Conduit.Process
-import Data.Monoid
-import System.Directory
-import System.Console.GetOpt
-import System.Environment
-import System.Exit
-import System.IO (Handle, stdout, stderr, hPutStrLn)
-import Text.Parsec.Char
-import Text.Parsec.String
+import           Conduit
+import           Control.Monad
+import           Control.Monad.Trans.Accum  (AccumT, add, evalAccumT, look)
+import qualified Data.Functor               (($>))
+import           Data.List.NonEmpty         (NonEmpty (..))
+import qualified Data.List.NonEmpty         as NE
+import           Data.Maybe                 (fromMaybe, isJust, isNothing)
+import           Data.Monoid
+import           System.Console.GetOpt
+import           System.Directory
+import           System.Environment
+import           System.Exit                (die, exitSuccess)
+import           System.IO                  (hPutStrLn, stderr)
 
-import Text.Pretty.Simple (pPrintForceColor)
+import           Data.Parsable              (runParsable)
+import           Distribution.Portage.Types
+import           Text.Pretty.Simple         (pPrintForceColor)
 
-import Data.Parsable
-import Distribution.Portage.Types
+import           RevdepScanner              (ConstraintMap, Debug,
+                                             MatchMode (..),
+                                             Mode (HelpMode, NormalMode), args,
+                                             lookupResults, parseAll,
+                                             prettyMatches, prettyProblems,
+                                             runOpaque, runTransparent)
 
 main :: IO ()
 main = do
-    pquery <- runEnv pqueryPath
-    (ps, mode, repoName, Any d) <- checkArgs
-
-    when d $ print $ pquery : args repoName
-
-    let f = if d then runTransparent else runOpaque
-
-    (_, out, _) <- f pquery (args repoName)
-    Right (m :: ConstraintMap) <- pure $ parseAll out
-
-    when d $ pPrintForceColor m
-
-    let ls = ps >>= \p -> do
-            let r = lookupResults mode p m
-            case mode of
-                Matching -> prettyMatches p r
-                NonMatching -> prettyProblems p r
-    putStr $ unlines $ NE.toList ls
-  where
-    args (Repository n) =
-        [ "--all"
-        , "--raw"
-        , "--unfiltered"
-        , "--repo", n
-        , "--atom"
-        , "--cpv"
-        , "--slot"
-        , "--attr", "depend"
-        , "--attr", "rdepend"
-        , "--attr", "bdepend"
-        , "-R"
-        , "--slot"
-        ]
-
-prettyProblems
-    :: Package
-    -> HashMap Revdep (HashSet ParsedDep)
-    -> NonEmpty String
-prettyProblems p m
-    | M.null m = NE.singleton
-        $ toString p ++ ": No problematic packages found!"
-    | otherwise
-        = (toString p ++ ":")
-        :| prettyResults m
-
-prettyMatches
-    :: Package
-    -> HashMap Revdep (HashSet ParsedDep)
-    -> NonEmpty String
-prettyMatches p m
-    | M.null m = NE.singleton
-        $ toString p ++ ": No matches found!"
-    | otherwise
-        = (toString p ++ ":")
-        :| prettyResults m
-
-prettyResults :: HashMap Revdep (HashSet ParsedDep) -> [String]
-prettyResults m =
-          sortBy (compare `on` fst) (M.toList m) >>= \((c,n,v,sl,r),s) ->
-                let p = Package c n (Just v) (Just sl) (Just r)
-                    svs = sortBy cmp (S.toList s)
-                in  [ "    " ++ toString p
-                    , "        ( " ++ L.intercalate " " (map toStr svs) ++ " )"
-                    ]
-  where
-    cmp :: ParsedDep -> ParsedDep -> Ordering
-    cmp pd1 pd2 = case (pd1, pd2) of
-        (Left (ConstrainedDep _ _ _ v1 _ _), Left (ConstrainedDep _ _ _ v2 _ _))
-            -> v1 `compare` v2
-        (Left _, Right _) -> GT
-        (Right _, Left _) -> LT
-        (_, _) -> EQ
-
-    toStr :: ParsedDep -> String
-    toStr = \case
-        Left cd -> toString cd
-        Right (c,n) -> toString $ Package c n Nothing Nothing Nothing
-
-lookupResults
-    :: MatchMode
-    -> Package
-    -> ConstraintMap
-    -> HashMap Revdep (HashSet ParsedDep)
-lookupResults mode p0@(Package c0 n0 _ _ _) m0 =
-    case M.lookup (c0, n0) m0 of
-        Just m -> foldr (M.unionWith S.union . go) M.empty (M.toList m)
-        Nothing -> M.empty
-  where
-    go :: (Revdep, HashSet (ParsedDep)) -> HashMap Revdep (HashSet ParsedDep)
-    go (r, s)
-        | any check s = M.singleton r s
-        | otherwise = M.empty
-
-    check d = case (mode, d) of
-        (Matching, Left cd) -> doesConstraintMatch cd p0
-        (Matching, Right (c,n)) -> c == c0 && n == n0
-        (NonMatching, Left cd) -> not (doesConstraintMatch cd p0)
-        (NonMatching, Right _) -> False
-
--- Types
-
-type ConstraintPkg = (Category, PkgName)
-type Revdep = (Category, PkgName, Version, Slot, Repository)
-type BasicDep = (Category, PkgName)
-type ParsedDep = Either ConstrainedDep BasicDep
-
--- | Organized by @(Category, PkgName)@
---
---   The inner map is keyed by the reverse dependency and contains a set of
---   constraints that match the same @(Category, PkgName)@ as the outermost key.
-type ConstraintMap = HashMap ConstraintPkg
-    (HashMap Revdep (HashSet ParsedDep))
-
-insertCM :: Revdep -> ParsedDep -> ConstraintMap -> ConstraintMap
-insertCM revdep dep cmap0 =
-    unionCM cmap0 $
-        M.singleton (ccat,cpkg) (M.singleton revdep (S.singleton dep))
-  where
-    (ccat, cpkg) = case dep of
-        Left (ConstrainedDep _ c p _ _ _) -> (c,p)
-        Right bDep -> bDep
-
-unionCM :: ConstraintMap -> ConstraintMap -> ConstraintMap
-unionCM = M.unionWith (M.unionWith S.union)
-
--- Parsing
-
-parseAll :: TL.Text -> Either ParseError ConstraintMap
-parseAll t = do
-    cms <- evalAccumT (traverse parseLine (TL.lines t)) (Sum 1)
-    pure $ foldr unionCM M.empty cms
-  where
-    parseLine :: TL.Text -> AccumT (Sum Int) (Either ParseError) ConstraintMap
-    parseLine l = do
-        Sum i <- look
-        add (Sum 1)
-        lift $ parse lineParser ("line " ++ show i) (TL.unpack l)
-
-lineParser :: Parser ConstraintMap
-lineParser = do
-    ConstrainedDep Equal rdCat rdPkg rdVer (Just rdSlot) (Just rdRepo) <-
-        parser @ConstrainedDep -- parser from Data.Parsable
-    let revdep = (rdCat, rdPkg, rdVer, rdSlot, rdRepo)
-    cds <- bruteForce
-    pure $ foldr (insertCM revdep) M.empty cds
-  where
-    -- Start with char 0, see if it's a valid ConstrainedDep /or/ Package.
-    -- Try next char, see if it's a valid ConstrainedDep /or Package.
-    -- etc...
-    bruteForce :: Parser [ParsedDep]
-    bruteForce = choice
-        [ try $ (:) <$> (Left <$> parser @ConstrainedDep) <*> bruteForce
-        , try $ do
-            Package c n Nothing _ _ <- parser
-            (Right (c,n) :) <$> bruteForce
-        , try $ [] <$ eof
-        , anyChar *> bruteForce
-        ]
+  pquery <- runEnv pqueryPath
+  (ps, mode, repoName, Any d) <- checkArgs
+  when d $ print $ pquery : args repoName
+  let f =
+        if d
+          then runTransparent
+          else runOpaque
+  (_, out, _) <- f pquery (args repoName)
+  Right (m :: ConstraintMap) <- pure $ parseAll out
+  when d $ pPrintForceColor m
+  let ls =
+        ps >>= \p -> do
+          let r = lookupResults mode p m
+          case mode of
+            Matching    -> prettyMatches p r
+            NonMatching -> prettyProblems p r
+  putStr $ unlines $ NE.toList ls
 
 -- Environment stuff
-
 type Env = AccumT (First FilePath) IO
 
 runEnv :: Env a -> IO a
@@ -205,128 +57,97 @@ runEnv = flip evalAccumT mempty
 -- | Find the path to the @pquery@ executable or throw an error. Caches the
 --   result in the case of a success.
 pqueryPath :: Env FilePath
-pqueryPath = look >>= \case
+pqueryPath =
+  look >>= \case
     First (Just p) -> pure p
-    First Nothing -> liftIO (findExecutable "pquery") >>= \case
-        Just p -> add (pure p) *> pure p
-        Nothing -> liftIO $
-            die "Could not find pquery executable. Install sys-apps/pkgcore first."
-
--- Util stuff
-
--- | Run a command and capture stdout and stderr
-runOpaque
-    :: FilePath -- ^ executable path
-    -> [String] -- ^ arguments
-       -- | Exit code, stdout, stderr
-    -> IO (ExitCode, TL.Text, TL.Text)
-runOpaque exe args
-    = sourceProcessWithStreams
-        (proc exe args)
-        (pure ())
-        (decodeUtf8LenientC .| sinkLazy)
-        (decodeUtf8LenientC .| sinkLazy)
-
--- | Run a command and dump stdout to @stdout@, stderr to @stderr@, also
---   capturing both streams.
-runTransparent
-    :: FilePath -- ^ executable path
-    -> [String] -- ^ arguments
-       -- | Exit code, stdout, stderr
-    -> IO (ExitCode, TL.Text, TL.Text)
-runTransparent exe args
-    = sourceProcessWithStreams (proc exe args) { delegate_ctlc = True }
-            (pure ()) (transSink stdout) (transSink stderr)
-  where
-    transSink :: Handle -> ConduitT BS.ByteString Void IO TL.Text
-    transSink h = iterMC (BS.hPut h) .| decodeUtf8LenientC .| sinkLazy
-
--- Command line
-
-type Debug = Any
-
-data MatchMode
-    = Matching
-    | NonMatching
-    deriving (Show, Eq, Ord)
-
-data Mode
-    = HelpMode
-    | NormalMode (Last MatchMode) (Last Repository) Debug
-    deriving (Show, Eq, Ord)
-
-instance Semigroup Mode where
-    HelpMode <> _ = HelpMode
-    _ <> HelpMode = HelpMode
-    NormalMode m1 r1 d1 <> NormalMode m2 r2 d2
-        = NormalMode (m1 <> m2) (r1 <> r2) (d1 <> d2)
-
-instance Monoid Mode where
-    mempty = NormalMode mempty mempty mempty
+    First Nothing ->
+      liftIO (findExecutable "pquery") >>= \case
+        Just p -> (add (pure p) Data.Functor.$> p)
+        Nothing ->
+          liftIO
+            $ die
+                "Could not find pquery executable. Install sys-apps/pkgcore first."
 
 checkArgs :: IO (NonEmpty Package, MatchMode, Repository, Debug)
 checkArgs = do
-    progName <- getProgName
-    argv <- getArgs
-    let err str = showHelp progName *> die ("error: " ++ str)
-
-    case getOpt Permute options argv of
-        (_,_,es@(_:_)) -> err (intercalate " " es)
-
-        (ms,as,_) -> case (mconcat ms, NE.nonEmpty as) of
-            (HelpMode, _) -> showHelp progName *> exitSuccess
-            (_, Nothing) -> err "At least one full package name (and optional \
-                           \version) required"
-            (NormalMode (Last mm) (Last mr) d, Just pStrs) ->
-                case traverse (runParsable "command line argument") pStrs of
-                    Left e -> err $
-                        "Invalid package: " ++ show e
-                    Right ps -> do
-                        m <- case mm of
-                            Just mode -> pure mode
-                            Nothing -> detectMode ps
-                        pure (ps, m, fromMaybe (Repository "haskell") mr, d)
+  progName <- getProgName
+  argv <- getArgs
+  let err str = showHelp progName *> die ("error: " ++ str)
+  case getOpt Permute options argv of
+    (_, _, es@(_:_)) -> err (unwords es)
+    (ms, as, _) ->
+      case (mconcat ms, NE.nonEmpty as) of
+        (HelpMode, _) -> showHelp progName *> exitSuccess
+        (_, Nothing) ->
+          err
+            "At least one full package name (and optional \
+           \version) required"
+        (NormalMode (Last mm) (Last mr) d, Just pStrs) ->
+          case traverse (runParsable "command line argument") pStrs of
+            Left e -> err $ "Invalid package: " ++ show e
+            Right ps -> do
+              m <-
+                case mm of
+                  Just mode -> pure mode
+                  Nothing   -> detectMode ps
+              pure (ps, m, fromMaybe (Repository "haskell") mr, d)
   where
     showHelp progName = putStrLn (usageInfo (header progName) options)
-
-    header progName = unlines $ unwords <$>
-        [ ["Usage:", progName, "[OPTION...]", "<cat/pkg[-ver]... >"]
-        , []
-        , ["This utility will scan a Gentoo repository and gather dependency information."]
-        , []
-        , ["--matching (default when no version is provided)"]
-        , ["Looks for dependencies that match the given package atom."]
-        , []
-        , ["--non-matching (default when version is provided)"]
-        , ["Looks for dependency constraints that would reject the provided"]
-        , ["package/version. For example:", "`" ++ progName, "dev-haskell/network-3.2` would"]
-        , ["match \"<dev-haskell/network-3.2\" as a problematic dependency."]
-        ]
-
+    header progName =
+      unlines
+        $ unwords
+            <$> [ ["Usage:", progName, "[OPTION...]", "<cat/pkg[-ver]... >"]
+                , []
+                , [ "This utility will scan a Gentoo repository and gather dependency information."
+                  ]
+                , []
+                , ["--matching (default when no version is provided)"]
+                , ["Looks for dependencies that match the given package atom."]
+                , []
+                , ["--non-matching (default when version is provided)"]
+                , [ "Looks for dependency constraints that would reject the provided"
+                  ]
+                , [ "package/version. For example:"
+                  , "`" ++ progName
+                  , "dev-haskell/network-3.2` would"
+                  ]
+                , [ "match \"<dev-haskell/network-3.2\" as a problematic dependency."
+                  ]
+                ]
     options :: [OptDescr Mode]
     options =
-        [ Option ['h'] ["help"] (NoArg HelpMode) "Show this help text"
-        , Option ['r'] ["repo"]
-            (ReqArg (\r -> NormalMode mempty (pure (Repository r)) mempty)
-                "REPOSITORY"
-            )
-            "Limit to a repository (defaults to \"haskell\")"
-        , Option [] ["debug"] (NoArg (NormalMode mempty mempty (Any True)))
-            "Display debug information"
-        , Option [] ["matching"]
-            (NoArg (NormalMode (pure Matching) mempty mempty))
-            "Look for matching dependencies"
-        , Option [] ["non-matching"]
-            (NoArg (NormalMode (pure NonMatching) mempty mempty))
-            "Look for non-matching relevant dependencies"
-        ]
-
+      [ Option ['h'] ["help"] (NoArg HelpMode) "Show this help text"
+      , Option
+          ['r']
+          ["repo"]
+          (ReqArg
+             (\r -> NormalMode mempty (pure (Repository r)) mempty)
+             "REPOSITORY")
+          "Limit to a repository (defaults to \"haskell\")"
+      , Option
+          []
+          ["debug"]
+          (NoArg (NormalMode mempty mempty (Any True)))
+          "Display debug information"
+      , Option
+          []
+          ["matching"]
+          (NoArg (NormalMode (pure Matching) mempty mempty))
+          "Look for matching dependencies"
+      , Option
+          []
+          ["non-matching"]
+          (NoArg (NormalMode (pure NonMatching) mempty mempty))
+          "Look for non-matching relevant dependencies"
+      ]
     detectMode :: Foldable f => f Package -> IO MatchMode
     detectMode ps
-        | all (isJust . getVersion) ps = pure NonMatching
-        | all (isNothing . getVersion) ps = pure Matching
-        | otherwise = do
-            hPutStrLn stderr "Warning: Mix of versioned and non-versioned \
-                             \packages were given on the command\n\
-                             \line. Defaulting to \"non-matching mode\"."
-            pure NonMatching
+      | all (isJust . getVersion) ps = pure NonMatching
+      | all (isNothing . getVersion) ps = pure Matching
+      | otherwise = do
+        hPutStrLn
+          stderr
+          "Warning: Mix of versioned and non-versioned \
+         \packages were given on the command\n\
+         \line. Defaulting to \"non-matching mode\"."
+        pure NonMatching


### PR DESCRIPTION
@hololeap : I was thinking of adding a possibility to use revdep-scanner with random-rebuild, to check that everything goes fine when we bump versions on a widely used package (looking at you, dev-haskell/data-default). And I was thinking that rather than running the executable, it might be better to use the core functions, so I separated your code between executable and library.

I see that my fixers went a little wild on Main.hs, so if it's of interest, I'll redo the Main.hs part in a cleaner way.